### PR TITLE
Add config option to multiply flight range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ out
 # gradle
 build
 .gradle
+gradlew
+gradlew.bat
+gradle/wrapper/gradle-wrapper.jar
+gradle/wrapper/gradle-wrapper.properties
 
 # other
 eclipse
@@ -23,7 +27,3 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
-gradlew
-gradlew.bat
-gradle/wrapper/gradle-wrapper.jar
-gradle/wrapper/gradle-wrapper.properties

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+gradlew
+gradlew.bat
+gradle/wrapper/gradle-wrapper.jar
+gradle/wrapper/gradle-wrapper.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Flight Conduit
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.1.1-1.20.1
+mod_version=1.1.2-1.20.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/net/jojosolos/flightconduit/Config.java
+++ b/src/main/java/net/jojosolos/flightconduit/Config.java
@@ -49,6 +49,10 @@ public class Config
             .comment("Distance from ground to disable feather falling\n\nOnly applies if featherFallingApplyNearGround is disabled\nDefault: 5 blocks, Range: 1 to 100 blocks")
             .defineInRange("featherFallingNearGroundBlocks", 5, 1, 100);
 
+    private static final ForgeConfigSpec.BooleanValue FEATHER_FALLING_DYNAMIC_DURATION = BUILDER
+            .comment("Calculate feather falling duration dynamically based on height above ground\n\nWhen enabled, applies exactly enough slow falling to safely reach the ground\nWhen disabled, uses the fixed featherFallingDuration value\nDefault: false")
+            .define("featherFallingDynamicDuration", false);
+
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
     public static Set<Block> blocks;
@@ -58,6 +62,7 @@ public class Config
     public static int featherFallingDuration;
     public static boolean featherFallingApplyNearGround;
     public static int featherFallingNearGroundBlocks;
+    public static boolean featherFallingDynamicDuration;
 
     private static boolean validateBlockName(final Object obj)
     {
@@ -77,5 +82,6 @@ public class Config
         featherFallingDuration = FEATHER_FALLING_DURATION.get();
         featherFallingApplyNearGround = FEATHER_FALLING_APPLY_NEAR_GROUND.get();
         featherFallingNearGroundBlocks = FEATHER_FALLING_NEAR_GROUND_BLOCKS.get();
+        featherFallingDynamicDuration = FEATHER_FALLING_DYNAMIC_DURATION.get();
     }
 }

--- a/src/main/java/net/jojosolos/flightconduit/Config.java
+++ b/src/main/java/net/jojosolos/flightconduit/Config.java
@@ -27,8 +27,8 @@ public class Config
                     Config::validateBlockName);
 
     private static final ForgeConfigSpec.DoubleValue RANGE_MULTIPLIER = BUILDER
-            .comment("Flight effect range multiplier\n\nMultiplies the default range calculation (frame_blocks / 7 * 10)\nDefault: 1.0, Range: 0.05 to 100.0")
-            .defineInRange("rangeMultiplier", 1.0, 0.05, 100.0);
+            .comment("Flight effect range multiplier\n\nMultiplies the default range calculation (frame_blocks / 7 * 10)\nDefault: 1.0, Range: 0.05 to 10.0")
+            .defineInRange("rangeMultiplier", 1.0, 0.05, 10.0);
 
     static final ForgeConfigSpec SPEC = BUILDER.build();
 

--- a/src/main/java/net/jojosolos/flightconduit/Config.java
+++ b/src/main/java/net/jojosolos/flightconduit/Config.java
@@ -1,7 +1,6 @@
 package net.jojosolos.flightconduit;
 
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -34,12 +33,12 @@ public class Config
             .comment("Feather falling (slow falling) effect duration in ticks\n\nApplied when exiting the flight conduit range\nDefault: 300 ticks (15 seconds), Range: 0 to 1200 ticks (60 seconds)")
             .defineInRange("featherFallingDuration", 300, 0, 1200);
 
-    private static final ForgeConfigSpec.BooleanValue FEATHER_FALLING_NEAR_GROUND = BUILDER
-            .comment("Disable feather falling when near ground\n\nWhen enabled, feather falling will not be applied if the player is within a certain distance of the ground\nDefault: false")
-            .define("featherFallingNearGround", false);
+    private static final ForgeConfigSpec.BooleanValue FEATHER_FALLING_APPLY_NEAR_GROUND = BUILDER
+            .comment("Should feather falling still apply when near ground?")
+            .define("featherFallingApplyNearGround", true);
 
     private static final ForgeConfigSpec.IntValue FEATHER_FALLING_NEAR_GROUND_BLOCKS = BUILDER
-            .comment("Distance from ground to disable feather falling\n\nOnly applies if featherFallingNearGround is enabled\nDefault: 5 blocks, Range: 1 to 20 blocks")
+            .comment("Distance from ground to disable feather falling\n\nOnly applies if featherFallingApplyNearGround is disabled\nDefault: 5 blocks, Range: 1 to 100 blocks")
             .defineInRange("featherFallingNearGroundBlocks", 5, 1, 100);
 
     static final ForgeConfigSpec SPEC = BUILDER.build();
@@ -47,7 +46,7 @@ public class Config
     public static Set<Block> blocks;
     public static double rangeMultiplier;
     public static int featherFallingDuration;
-    public static boolean featherFallingNearGround;
+    public static boolean featherFallingApplyNearGround;
     public static int featherFallingNearGroundBlocks;
 
     private static boolean validateBlockName(final Object obj)
@@ -64,7 +63,7 @@ public class Config
         
         rangeMultiplier = RANGE_MULTIPLIER.get();
         featherFallingDuration = FEATHER_FALLING_DURATION.get();
-        featherFallingNearGround = FEATHER_FALLING_NEAR_GROUND.get();
+        featherFallingApplyNearGround = FEATHER_FALLING_APPLY_NEAR_GROUND.get();
         featherFallingNearGroundBlocks = FEATHER_FALLING_NEAR_GROUND_BLOCKS.get();
     }
 }

--- a/src/main/java/net/jojosolos/flightconduit/Config.java
+++ b/src/main/java/net/jojosolos/flightconduit/Config.java
@@ -34,11 +34,21 @@ public class Config
             .comment("Feather falling (slow falling) effect duration in ticks\n\nApplied when exiting the flight conduit range\nDefault: 300 ticks (15 seconds), Range: 0 to 1200 ticks (60 seconds)")
             .defineInRange("featherFallingDuration", 300, 0, 1200);
 
+    private static final ForgeConfigSpec.BooleanValue FEATHER_FALLING_NEAR_GROUND = BUILDER
+            .comment("Disable feather falling when near ground\n\nWhen enabled, feather falling will not be applied if the player is within a certain distance of the ground\nDefault: false")
+            .define("featherFallingNearGround", false);
+
+    private static final ForgeConfigSpec.IntValue FEATHER_FALLING_NEAR_GROUND_BLOCKS = BUILDER
+            .comment("Distance from ground to disable feather falling\n\nOnly applies if featherFallingNearGround is enabled\nDefault: 5 blocks, Range: 1 to 20 blocks")
+            .defineInRange("featherFallingNearGroundBlocks", 5, 1, 100);
+
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
     public static Set<Block> blocks;
     public static double rangeMultiplier;
     public static int featherFallingDuration;
+    public static boolean featherFallingNearGround;
+    public static int featherFallingNearGroundBlocks;
 
     private static boolean validateBlockName(final Object obj)
     {
@@ -54,5 +64,7 @@ public class Config
         
         rangeMultiplier = RANGE_MULTIPLIER.get();
         featherFallingDuration = FEATHER_FALLING_DURATION.get();
+        featherFallingNearGround = FEATHER_FALLING_NEAR_GROUND.get();
+        featherFallingNearGroundBlocks = FEATHER_FALLING_NEAR_GROUND_BLOCKS.get();
     }
 }

--- a/src/main/java/net/jojosolos/flightconduit/Config.java
+++ b/src/main/java/net/jojosolos/flightconduit/Config.java
@@ -29,6 +29,14 @@ public class Config
             .comment("Flight effect range multiplier\n\nMultiplies the default range calculation (frame_blocks / 7 * 10)\nDefault: 1.0, Range: 0.05 to 10.0")
             .defineInRange("rangeMultiplier", 1.0, 0.05, 10.0);
 
+    private static final ForgeConfigSpec.IntValue FLIGHT_CHECK_INTERVAL = BUILDER
+            .comment("How often (in ticks) to check and reapply flight effect to players in range\n\nDefault: 40 ticks (2 seconds), Range: 5 to 100 ticks")
+            .defineInRange("flightCheckInterval", 40, 5, 100);
+
+    private static final ForgeConfigSpec.IntValue FLIGHT_EFFECT_DURATION = BUILDER
+            .comment("How long the flight effect lasts when applied\n\nShould be longer than check interval to prevent effect flickering (and falling)\nDefault: 260 ticks (13 seconds), Range: 20 to 600 ticks")
+            .defineInRange("flightEffectDuration", 260, 20, 600);
+
     private static final ForgeConfigSpec.IntValue FEATHER_FALLING_DURATION = BUILDER
             .comment("Feather falling (slow falling) effect duration in ticks\n\nApplied when exiting the flight conduit range\nDefault: 300 ticks (15 seconds), Range: 0 to 1200 ticks (60 seconds)")
             .defineInRange("featherFallingDuration", 300, 0, 1200);
@@ -45,6 +53,8 @@ public class Config
 
     public static Set<Block> blocks;
     public static double rangeMultiplier;
+    public static int flightCheckInterval;
+    public static int flightEffectDuration;
     public static int featherFallingDuration;
     public static boolean featherFallingApplyNearGround;
     public static int featherFallingNearGroundBlocks;
@@ -62,6 +72,8 @@ public class Config
                 .collect(Collectors.toSet());
         
         rangeMultiplier = RANGE_MULTIPLIER.get();
+        flightCheckInterval = FLIGHT_CHECK_INTERVAL.get();
+        flightEffectDuration = FLIGHT_EFFECT_DURATION.get();
         featherFallingDuration = FEATHER_FALLING_DURATION.get();
         featherFallingApplyNearGround = FEATHER_FALLING_APPLY_NEAR_GROUND.get();
         featherFallingNearGroundBlocks = FEATHER_FALLING_NEAR_GROUND_BLOCKS.get();

--- a/src/main/java/net/jojosolos/flightconduit/Config.java
+++ b/src/main/java/net/jojosolos/flightconduit/Config.java
@@ -30,10 +30,15 @@ public class Config
             .comment("Flight effect range multiplier\n\nMultiplies the default range calculation (frame_blocks / 7 * 10)\nDefault: 1.0, Range: 0.05 to 10.0")
             .defineInRange("rangeMultiplier", 1.0, 0.05, 10.0);
 
+    private static final ForgeConfigSpec.IntValue FEATHER_FALLING_DURATION = BUILDER
+            .comment("Feather falling (slow falling) effect duration in ticks\n\nApplied when exiting the flight conduit range\nDefault: 300 ticks (15 seconds), Range: 0 to 1200 ticks (60 seconds)")
+            .defineInRange("featherFallingDuration", 300, 0, 1200);
+
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
     public static Set<Block> blocks;
     public static double rangeMultiplier;
+    public static int featherFallingDuration;
 
     private static boolean validateBlockName(final Object obj)
     {
@@ -48,5 +53,6 @@ public class Config
                 .collect(Collectors.toSet());
         
         rangeMultiplier = RANGE_MULTIPLIER.get();
+        featherFallingDuration = FEATHER_FALLING_DURATION.get();
     }
 }

--- a/src/main/java/net/jojosolos/flightconduit/Config.java
+++ b/src/main/java/net/jojosolos/flightconduit/Config.java
@@ -26,9 +26,14 @@ public class Config
                     List.of("minecraft:oxidized_copper", "minecraft:waxed_oxidized_copper", "minecraft:weathered_copper", "minecraft:waxed_weathered_copper"),
                     Config::validateBlockName);
 
+    private static final ForgeConfigSpec.DoubleValue RANGE_MULTIPLIER = BUILDER
+            .comment("Flight effect range multiplier\n\nMultiplies the default range calculation (frame_blocks / 7 * 10)\nDefault: 1.0, Range: 0.05 to 100.0")
+            .defineInRange("rangeMultiplier", 1.0, 0.05, 100.0);
+
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
     public static Set<Block> blocks;
+    public static double rangeMultiplier;
 
     private static boolean validateBlockName(final Object obj)
     {
@@ -41,5 +46,7 @@ public class Config
         blocks = BLOCK_STRINGS.get().stream()
                 .map(blockName -> ForgeRegistries.BLOCKS.getValue(new ResourceLocation(blockName)))
                 .collect(Collectors.toSet());
+        
+        rangeMultiplier = RANGE_MULTIPLIER.get();
     }
 }

--- a/src/main/java/net/jojosolos/flightconduit/block/entity/FlightConduitBlockEntity.java
+++ b/src/main/java/net/jojosolos/flightconduit/block/entity/FlightConduitBlockEntity.java
@@ -100,7 +100,7 @@ public class FlightConduitBlockEntity extends BlockEntity {
         ++pBlockEntity.tickCount;
         long i = pLevel.getGameTime();
         List<BlockPos> list = pBlockEntity.effectBlocks;
-        if (i % 40L == 0L) {
+        if (i % Config.flightCheckInterval == 0L) {
             boolean flag = updateShape(pLevel, pPos, list);
             if (flag != pBlockEntity.isActive) {
                 SoundEvent soundevent = flag ? SoundEvents.CONDUIT_ACTIVATE : SoundEvents.CONDUIT_DEACTIVATE;
@@ -180,7 +180,7 @@ public class FlightConduitBlockEntity extends BlockEntity {
         if (!list.isEmpty()) {
             for(Player player : list) {
                 if (pPos.closerThan(player.blockPosition(), (double)j)) {
-                    player.addEffect(new MobEffectInstance(ModEffects.FLIGHT.get(), 260, 0, true, false, true));
+                    player.addEffect(new MobEffectInstance(ModEffects.FLIGHT.get(), Config.flightEffectDuration, 0, true, false, true));
                 }
             }
 

--- a/src/main/java/net/jojosolos/flightconduit/block/entity/FlightConduitBlockEntity.java
+++ b/src/main/java/net/jojosolos/flightconduit/block/entity/FlightConduitBlockEntity.java
@@ -171,7 +171,7 @@ public class FlightConduitBlockEntity extends BlockEntity {
 
     private static void applyEffects(Level pLevel, BlockPos pPos, List<BlockPos> pPositions) {
         int i = pPositions.size();
-        int j = i / 7 * 10;
+        int j = (int) (i / 7 * 10 * Config.rangeMultiplier);
         int k = pPos.getX();
         int l = pPos.getY();
         int i1 = pPos.getZ();

--- a/src/main/java/net/jojosolos/flightconduit/event/ModEvents.java
+++ b/src/main/java/net/jojosolos/flightconduit/event/ModEvents.java
@@ -27,18 +27,35 @@ public class ModEvents {
             player.getAbilities().flying = false;
             player.onUpdateAbilities();
 
+            // Get distance to ground for both checking if we should apply and calculating duration
+            double distanceToGround = getDistanceToGround(player);
+            
             // Check if we should apply feather falling
-            // If featherFallingApplyNearGround, we don't need to check distance always apply no matter what
             boolean shouldApplyFeatherFalling = true;
             if (!Config.featherFallingApplyNearGround) {
-                double distanceToGround = getDistanceToGround(player);
                 if (distanceToGround <= Config.featherFallingNearGroundBlocks) {
                     shouldApplyFeatherFalling = false;
                 }
             }
             
             if (shouldApplyFeatherFalling) {
-                player.addEffect(new MobEffectInstance(MobEffects.SLOW_FALLING, Config.featherFallingDuration, 1));
+                int duration;
+                
+                if (Config.featherFallingDynamicDuration) {
+                    // Calculate exact duration needed based on height above ground
+                    // With slow falling, players fall at approximately 0.125 blocks per tick
+                    // So duration = distance / 0.125 = distance * 8
+                    // Add a small buffer (20 ticks = 1 second) to ensure safe landing
+                    duration = (int) Math.ceil(distanceToGround * 8.0) + 20;
+                    
+                    // Clamp duration to reasonable bounds (minimum 20 ticks, maximum 1200 ticks)
+                    duration = Math.max(20, Math.min(1200, duration));
+                } else {
+                    // Use configured static duration
+                    duration = Config.featherFallingDuration;
+                }
+                
+                player.addEffect(new MobEffectInstance(MobEffects.SLOW_FALLING, duration, 1));
             }
         }
     }
@@ -47,9 +64,14 @@ public class ModEvents {
         Level level = player.level();
         BlockPos playerPos = player.blockPosition();
         
+        // Determine search distance based on whether we need accurate measurements for dynamic duration
+        // If dynamic duration is enabled, search up to 150 blocks (which would give ~1200 tick duration)
+        // Otherwise, only search enough to check the near-ground threshold
+        int searchDistance = Config.featherFallingDynamicDuration 
+            ? 150 
+            : (Config.featherFallingNearGroundBlocks + 10);
+        
         // Search downward from player position to find the first solid block
-        // Search twice the configured distance to ensure we can accurately determine if player is within range
-        int searchDistance = Config.featherFallingNearGroundBlocks + 10;
         for (int i = 0; i < searchDistance; i++) {
             BlockPos checkPos = playerPos.below(i);
             

--- a/src/main/java/net/jojosolos/flightconduit/event/ModEvents.java
+++ b/src/main/java/net/jojosolos/flightconduit/event/ModEvents.java
@@ -28,10 +28,9 @@ public class ModEvents {
             player.onUpdateAbilities();
 
             // Check if we should apply feather falling
+            // If featherFallingApplyNearGround, we don't need to check distance always apply no matter what
             boolean shouldApplyFeatherFalling = true;
-            
-            if (Config.featherFallingNearGround) {
-                // Check distance to ground
+            if (!Config.featherFallingApplyNearGround) {
                 double distanceToGround = getDistanceToGround(player);
                 if (distanceToGround <= Config.featherFallingNearGroundBlocks) {
                     shouldApplyFeatherFalling = false;
@@ -49,7 +48,9 @@ public class ModEvents {
         BlockPos playerPos = player.blockPosition();
         
         // Search downward from player position to find the first solid block
-        for (int i = 0; i < Config.featherFallingNearGroundBlocks + 10; i++) {
+        // Search twice the configured distance to ensure we can accurately determine if player is within range
+        int searchDistance = Config.featherFallingNearGroundBlocks + 10;
+        for (int i = 0; i < searchDistance; i++) {
             BlockPos checkPos = playerPos.below(i);
             
             // Check if we've reached the bottom of the world
@@ -63,7 +64,7 @@ public class ModEvents {
             }
         }
         
-        // If no ground found within search range, return a large number
-        return Config.featherFallingNearGroundBlocks + 1;
+        // If no ground found within search range, return a distance larger than our check range
+        return searchDistance + 10;
     }
 }

--- a/src/main/java/net/jojosolos/flightconduit/event/ModEvents.java
+++ b/src/main/java/net/jojosolos/flightconduit/event/ModEvents.java
@@ -1,5 +1,6 @@
 package net.jojosolos.flightconduit.event;
 
+import net.jojosolos.flightconduit.Config;
 import net.jojosolos.flightconduit.FlightConduit;
 import net.jojosolos.flightconduit.effect.ModEffects;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -24,7 +25,7 @@ public class ModEvents {
             player.getAbilities().flying = false;
             player.onUpdateAbilities();
 
-            player.addEffect(new MobEffectInstance(MobEffects.SLOW_FALLING, 300, 1));
+            player.addEffect(new MobEffectInstance(MobEffects.SLOW_FALLING, Config.featherFallingDuration, 1));
         }
     }
 }

--- a/src/main/resources/assets/flightconduit/blockstates/flight_conduit_block.json
+++ b/src/main/resources/assets/flightconduit/blockstates/flight_conduit_block.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "flightconduit:block/flight_conduit_block"
+    }
+  }
+}

--- a/src/main/resources/assets/flightconduit/models/block/flight_conduit_block.json
+++ b/src/main/resources/assets/flightconduit/models/block/flight_conduit_block.json
@@ -1,5 +1,21 @@
 {
-	"textures": {
-		"particle": "flightconduit:block/flight_conduit_block"
-	}
+  "textures": {
+    "0": "flightconduit:block/flight_conduit_block",
+    "particle": "flightconduit:block/flight_conduit_block"
+  },
+  "elements": [
+    {
+      "from": [5, 5, 5],
+      "to": [11, 11, 11],
+      "rotation": {"angle": 0, "axis": "y", "origin": [7, 7, 7]},
+      "faces": {
+        "north": {"uv": [8, 8, 14, 14], "texture": "#0"},
+        "east": {"uv": [8, 2, 14, 8], "texture": "#0"},
+        "south": {"uv": [8, 8, 14, 14], "texture": "#0"},
+        "west": {"uv": [2, 8, 8, 14], "texture": "#0"},
+        "up": {"uv": [2, 2, 8, 8], "texture": "#0"},
+        "down": {"uv": [2, 2, 8, 8], "texture": "#0"}
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This adds a simple config option which is a multiplier to extend or shrink the flight range.

It adds a single config option, (a double) which acts a multiplier on the range of the conduit.  (0.5 cuts in half, 1.0 is default, 2.0 doubles, etc)

I'm not sure if this is the best place to add such a modifier, but it seemed to be by far the easiest to me.  This only affects the flight range.  Phantom range is unaffected.  (i think)